### PR TITLE
Support Paginating Struct Pointer Slices

### DIFF
--- a/paginator.go
+++ b/paginator.go
@@ -185,7 +185,11 @@ func (p *Paginator) postProcess(out interface{}) {
 func (p *Paginator) encode(v reflect.Value) string {
 	fields := make([]string, len(p.keys))
 	for index, key := range p.keys {
-		fields[index] = convert(v.FieldByName(key).Interface())
+		if v.Kind() == reflect.Ptr {
+			fields[index] = convert(reflect.Indirect(v).FieldByName(key).Interface())
+		} else {
+			fields[index] = convert(v.FieldByName(key).Interface())
+		}
 	}
 	return encodeBase64(fields)
 }

--- a/paginator_test.go
+++ b/paginator_test.go
@@ -74,6 +74,36 @@ func (s *paginatorSuite) TestPaginateWithDefaultOptions() {
 	s.assertOnlyAfter(cursor)
 }
 
+func (s *paginatorSuite) TestPaginateWithSliceStructPointersDefaultOptions() {
+	var ordersPtrs []*order
+	var orders = s.givenOrders(12)
+
+	// Create Slice of order pointers
+	for i := 0; i < len(orders); i++ {
+		ordersPtrs = append(ordersPtrs, &orders[i])
+	}
+
+	var o1 []*order
+	p1 := New()
+	cursor := s.paginate(p1, s.db, &o1)
+	s.assertPtrOrders(ordersPtrs, 11, 2, o1)
+	s.assertOnlyAfter(cursor)
+
+	var o2 []*order
+	p2 := New()
+	p2.SetAfterCursor(*cursor.After)
+	cursor = s.paginate(p2, s.db, &o2)
+	s.assertPtrOrders(ordersPtrs, 1, 0, o2)
+	s.assertOnlyBefore(cursor)
+
+	var o3 []*order
+	p3 := New()
+	p3.SetBeforeCursor(*cursor.Before)
+	cursor = s.paginate(p3, s.db, &o3)
+	s.Equal(o1, o3)
+	s.assertOnlyAfter(cursor)
+}
+
 func (s *paginatorSuite) TestPaginateAfterCursorShouldTakePrecedenceOverBeforeCursor() {
 	var orders = s.givenOrders(10)
 
@@ -320,6 +350,11 @@ func (s *paginatorSuite) assertBoth(cursor Cursor) {
 }
 
 func (s *paginatorSuite) assertOrders(expected []order, head, tail int, got []order) {
+	s.Equal(expected[head].ID, got[first(got)].ID)
+	s.Equal(expected[tail].ID, got[last(got)].ID)
+}
+
+func (s *paginatorSuite) assertPtrOrders(expected []*order, head, tail int, got []*order) {
 	s.Equal(expected[head].ID, got[first(got)].ID)
 	s.Equal(expected[tail].ID, got[last(got)].ID)
 }


### PR DESCRIPTION
- Added code to check paginated slice item if pointer.
- Use `Indirect()` if slice item is a pointer to get cursor field
- Wrote default test that uses order pointers `orderPtrs` against the default pagination test that tests the results against original orders.
- Feel free to try running the test case I added with current library code to see the Error `reflect: call of reflect.Value.FieldByName on ptr Value`.