### PR TITLE
Support encoding/decoding structs

### DIFF
--- a/cursor_decoder.go
+++ b/cursor_decoder.go
@@ -1,6 +1,7 @@
 package paginator
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -16,59 +17,33 @@ type CursorDecoder interface {
 
 // NewCursorDecoder creates cursor decoder
 func NewCursorDecoder(ref interface{}, keys ...string) (CursorDecoder, error) {
-	decoder := &cursorDecoder{keys: keys}
-	err := decoder.initKeyKinds(ref)
-	if err != nil {
-		return nil, err
+	// Get the reflected type
+	rt := toReflectValue(ref).Type()
+
+	// Reduce reflect type to underlying struct
+	for rt.Kind() == reflect.Slice || rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
 	}
-	return decoder, nil
+
+	if rt.Kind() != reflect.Struct {
+		// element of out must be struct, if not, just pass it to gorm to handle the error
+		return nil, ErrInvalidDecodeReference
+	}
+
+	return &cursorDecoder{ref: rt, keys: keys}, nil
 }
 
 // Errors for decoders
 var (
 	ErrInvalidDecodeReference = errors.New("decode reference should be struct")
 	ErrInvalidField           = errors.New("invalid field")
-	ErrInvalidFieldType       = errors.New("invalid field type")
+	errInvalidOldField        = errors.New("invalid old field")
 )
-
-type kind uint
-
-const (
-	kindInvalid kind = iota
-	kindBool
-	kindInt
-	kindUint
-	kindFloat
-	kindString
-	kindTime
-)
-
-func toKind(rt reflect.Type) kind {
-	// reduce reflect type to underlying value
-	for rt.Kind() == reflect.Ptr {
-		rt = rt.Elem()
-	}
-	// Kind() treats time.Time as struct, so we need specific test for time.Time
-	if rt.ConvertibleTo(reflect.TypeOf(time.Time{})) {
-		return kindTime
-	}
-	switch rt.Kind() {
-	case reflect.Bool:
-		return kindBool
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return kindInt
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return kindUint
-	case reflect.Float32, reflect.Float64:
-		return kindFloat
-	default:
-		return kindString
-	}
-}
 
 type cursorDecoder struct {
-	keys     []string
-	keyKinds []kind
+	// ref is the reference objects reflected type
+	ref  reflect.Type
+	keys []string
 }
 
 func (d *cursorDecoder) Decode(cursor string) []interface{} {
@@ -77,99 +52,52 @@ func (d *cursorDecoder) Decode(cursor string) []interface{} {
 	if err != nil {
 		return nil
 	}
-	var fields []interface{}
-	err = json.Unmarshal(b, &fields)
-	// ensure backward compatibility, should be deprecated in v2
+
+	// Create a JSON decoder
+	dec := json.NewDecoder(bytes.NewBuffer(b))
+
+	// Read open bracket
+	_, err = dec.Token()
 	if err != nil {
-		return decodeOld(b)
+		return nil
 	}
-	return d.castJSONFields(fields)
-}
 
-func (d *cursorDecoder) initKeyKinds(ref interface{}) error {
-	// @TODO: zero value error
-	rt := toReflectValue(ref).Type()
-	// reduce reflect type to underlying struct
-	for rt.Kind() == reflect.Slice || rt.Kind() == reflect.Ptr {
-		rt = rt.Elem()
-	}
-	if rt.Kind() != reflect.Struct {
-		// element of out must be struct, if not, just pass it to gorm to handle the error
-		return ErrInvalidDecodeReference
-	}
-	d.keyKinds = make([]kind, len(d.keys))
+	// Iterate over each key and decode the value
+	result := make([]interface{}, len(d.keys))
 	for i, key := range d.keys {
-		field, ok := rt.FieldByName(key)
+		// Find the field in the struct
+		field, ok := d.ref.FieldByName(key)
 		if !ok {
-			return ErrInvalidField
-		}
-		d.keyKinds[i] = toKind(field.Type)
-	}
-	return nil
-}
-
-func (d *cursorDecoder) castJSONFields(fields []interface{}) []interface{} {
-	var result []interface{}
-	for i, field := range fields {
-		kind := d.keyKinds[i]
-		switch f := field.(type) {
-		case bool:
-			bv, err := castJSONBool(f, kind)
-			if err != nil {
-				return nil
-			}
-			result = append(result, bv)
-		case float64:
-			fv, err := castJSONFloat(f, kind)
-			if err != nil {
-				return nil
-			}
-			result = append(result, fv)
-		case string:
-			sv, err := castJSONString(f, kind)
-			if err != nil {
-				return nil
-			}
-			result = append(result, sv)
-		default:
-			// invalid field
 			return nil
 		}
+
+		// Get a copy of the field. JSON decoding requires a pointer but we want
+		// to return the same type as that of the referenced object. Therefore
+		// capture whether the value is a pointer or not and we will dereference
+		// the unmarshalled value before returning it if it is not originally a
+		// pointer.
+		isPtr := false
+		objType := field.Type
+		if objType.Kind() == reflect.Ptr {
+			isPtr = true
+			objType = objType.Elem()
+		}
+		v := reflect.New(objType).Interface()
+
+		// Decode the value
+		err := dec.Decode(&v)
+		if err != nil {
+			return decodeOld(b)
+		}
+
+		// Need to dereference since everything is now a pointer
+		if !isPtr {
+			v = reflect.ValueOf(v).Elem().Interface()
+		}
+		result[i] = v
 	}
+
 	return result
-}
-
-func castJSONBool(value bool, kind kind) (interface{}, error) {
-	if kind != kindBool {
-		return nil, ErrInvalidFieldType
-	}
-	return value, nil
-}
-
-func castJSONFloat(value float64, kind kind) (interface{}, error) {
-	switch kind {
-	case kindInt:
-		return int(value), nil
-	case kindUint:
-		return uint(value), nil
-	case kindFloat:
-		return value, nil
-	}
-	return nil, ErrInvalidFieldType
-}
-
-func castJSONString(value string, kind kind) (interface{}, error) {
-	if kind != kindString && kind != kindTime {
-		return nil, ErrInvalidFieldType
-	}
-	if kind == kindString {
-		return value, nil
-	}
-	tv, err := time.Parse(time.RFC3339Nano, value)
-	if err != nil {
-		return nil, ErrInvalidFieldType
-	}
-	return tv, nil
 }
 
 /* deprecated */
@@ -178,7 +106,13 @@ func decodeOld(b []byte) []interface{} {
 	fieldsWithType := strings.Split(string(b), ",")
 	fields := make([]interface{}, len(fieldsWithType))
 	for i, fieldWithType := range fieldsWithType {
-		fields[i] = revert(fieldWithType)
+		v, err := revert(fieldWithType)
+		if err != nil {
+			// Failed to parse old encoding
+			return nil
+		}
+
+		fields[i] = v
 	}
 	return fields
 }
@@ -190,23 +124,31 @@ const (
 	fieldTime   fieldType = "TIME"
 )
 
-func revert(fieldWithType string) interface{} {
-	field, fieldType := parse(fieldWithType)
+func revert(fieldWithType string) (interface{}, error) {
+	field, fieldType, err := parse(fieldWithType)
+	if err != nil {
+		return nil, err
+	}
+
 	switch fieldType {
 	case fieldTime:
 		t, err := time.Parse(time.RFC3339Nano, field)
 		if err != nil {
 			t = time.Now().UTC()
 		}
-		return t
+		return t, nil
 	default:
-		return field
+		return field, nil
 	}
 }
 
-func parse(fieldWithType string) (string, fieldType) {
+func parse(fieldWithType string) (string, fieldType, error) {
 	sep := strings.LastIndex(fieldWithType, "?")
+	if sep == -1 {
+		return "", fieldString, errInvalidOldField
+	}
+
 	field := fieldWithType[:sep]
 	fieldType := fieldType(fieldWithType[sep+1:])
-	return field, fieldType
+	return field, fieldType, nil
 }

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -142,12 +142,17 @@ func (s *cursorSuite) TestCursorDeprecatedDecodeBackwardCompatibility() {
 /* cursor test model */
 
 type cursorModel struct {
-	Bool   bool
-	Int    int
-	Uint   uint
-	Float  float64
-	String string
-	Time   time.Time
+	Bool     bool
+	Int      int
+	Uint     uint
+	Float    float64
+	String   string
+	Time     time.Time
+	Embedded embeddedModel
+}
+
+type embeddedModel struct {
+	Bytes []byte
 }
 
 func createCursorModelFixture() cursorModel {
@@ -158,6 +163,9 @@ func createCursorModelFixture() cursorModel {
 		Float:  3.14,
 		String: "hello",
 		Time:   time.Now(),
+		Embedded: embeddedModel{
+			Bytes: []byte{'t', 'e', 's', 't'},
+		},
 	}
 }
 
@@ -166,7 +174,7 @@ func (m *cursorModel) FieldCount() int {
 }
 
 func (m *cursorModel) Keys() []string {
-	return []string{"Bool", "Int", "Uint", "Float", "String", "Time"}
+	return []string{"Bool", "Int", "Uint", "Float", "String", "Time", "Embedded"}
 }
 
 func (m *cursorModel) Encode() string {
@@ -241,6 +249,10 @@ func (s *cursorSuite) assertFields(model cursorModel, fields []interface{}) {
 
 	timeVal, _ := fields[5].(time.Time)
 	s.assertTime(model.Time, timeVal)
+
+	embeddedVal, ok := fields[4].(embeddedModel)
+	s.True(ok)
+	s.Equal(model.Embedded.Bytes, embeddedVal.Bytes)
 }
 
 func (s *cursorSuite) assertDeprecatedFields(model cursorModel, fields []interface{}) {

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -142,13 +142,14 @@ func (s *cursorSuite) TestCursorDeprecatedDecodeBackwardCompatibility() {
 /* cursor test model */
 
 type cursorModel struct {
-	Bool     bool
-	Int      int
-	Uint     uint
-	Float    float64
-	String   string
-	Time     time.Time
-	Embedded embeddedModel
+	Bool        bool
+	Int         int
+	Uint        uint
+	Float       float64
+	String      string
+	Time        time.Time
+	Embedded    embeddedModel
+	EmbeddedPtr *embeddedModel
 }
 
 type embeddedModel struct {
@@ -166,6 +167,9 @@ func createCursorModelFixture() cursorModel {
 		Embedded: embeddedModel{
 			Bytes: []byte{'t', 'e', 's', 't'},
 		},
+		EmbeddedPtr: &embeddedModel{
+			Bytes: []byte{'t', 'e', 's', 't', '2'},
+		},
 	}
 }
 
@@ -174,7 +178,7 @@ func (m *cursorModel) FieldCount() int {
 }
 
 func (m *cursorModel) Keys() []string {
-	return []string{"Bool", "Int", "Uint", "Float", "String", "Time", "Embedded"}
+	return []string{"Bool", "Int", "Uint", "Float", "String", "Time", "Embedded", "EmbeddedPtr"}
 }
 
 func (m *cursorModel) Encode() string {
@@ -250,9 +254,11 @@ func (s *cursorSuite) assertFields(model cursorModel, fields []interface{}) {
 	timeVal, _ := fields[5].(time.Time)
 	s.assertTime(model.Time, timeVal)
 
-	embeddedVal, ok := fields[4].(embeddedModel)
-	s.True(ok)
+	embeddedVal, _ := fields[6].(embeddedModel)
 	s.Equal(model.Embedded.Bytes, embeddedVal.Bytes)
+
+	embeddedPtrVal, _ := fields[7].(*embeddedModel)
+	s.Equal(model.EmbeddedPtr.Bytes, embeddedPtrVal.Bytes)
 }
 
 func (s *cursorSuite) assertDeprecatedFields(model cursorModel, fields []interface{}) {

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -142,18 +142,18 @@ func (s *cursorSuite) TestCursorDeprecatedDecodeBackwardCompatibility() {
 /* cursor test model */
 
 type cursorModel struct {
-	Bool        bool
-	Int         int
-	Uint        uint
-	Float       float64
-	String      string
-	Time        time.Time
-	Embedded    embeddedModel
-	EmbeddedPtr *embeddedModel
+	Bool           bool
+	Int            int
+	Uint           uint
+	Float          float64
+	String         string
+	Time           time.Time
+	StructField    structField
+	StructFieldPtr *structField
 }
 
-type embeddedModel struct {
-	Bytes []byte
+type structField struct {
+	Value []byte
 }
 
 func createCursorModelFixture() cursorModel {
@@ -164,11 +164,11 @@ func createCursorModelFixture() cursorModel {
 		Float:  3.14,
 		String: "hello",
 		Time:   time.Now(),
-		Embedded: embeddedModel{
-			Bytes: []byte{'t', 'e', 's', 't'},
+		StructField: structField{
+			Value: []byte{'t', 'e', 's', 't'},
 		},
-		EmbeddedPtr: &embeddedModel{
-			Bytes: []byte{'t', 'e', 's', 't', '2'},
+		StructFieldPtr: &structField{
+			Value: []byte{'t', 'e', 's', 't', '2'},
 		},
 	}
 }
@@ -178,7 +178,7 @@ func (m *cursorModel) FieldCount() int {
 }
 
 func (m *cursorModel) Keys() []string {
-	return []string{"Bool", "Int", "Uint", "Float", "String", "Time", "Embedded", "EmbeddedPtr"}
+	return []string{"Bool", "Int", "Uint", "Float", "String", "Time", "StructField", "StructFieldPtr"}
 }
 
 func (m *cursorModel) Encode() string {
@@ -254,11 +254,11 @@ func (s *cursorSuite) assertFields(model cursorModel, fields []interface{}) {
 	timeVal, _ := fields[5].(time.Time)
 	s.assertTime(model.Time, timeVal)
 
-	embeddedVal, _ := fields[6].(embeddedModel)
-	s.Equal(model.Embedded.Bytes, embeddedVal.Bytes)
+	embeddedVal, _ := fields[6].(structField)
+	s.Equal(model.StructField.Value, embeddedVal.Value)
 
-	embeddedPtrVal, _ := fields[7].(*embeddedModel)
-	s.Equal(model.EmbeddedPtr.Bytes, embeddedPtrVal.Bytes)
+	embeddedPtrVal, _ := fields[7].(*structField)
+	s.Equal(model.StructFieldPtr.Value, embeddedPtrVal.Value)
 }
 
 func (s *cursorSuite) assertDeprecatedFields(model cursorModel, fields []interface{}) {


### PR DESCRIPTION
This PR reworks how the cursor decoder works to support decoding structs. I believe it also simplifies the logic by removing custom type tracking. I added tests to support both an embedded struct and and a pointer to a struct.

The summary of the logic is to decode each element of the JSON array directly to the reflected zero value of the referenced struct by key name.

Primary motivation is we have a type that is roughly as follows:

```
type Model struct {
  ID UUID
  CreatedAt time.Time
}

type UUID struct {
  UUID []byte
}
```

The first commit adds a test showing that this behavior did not work.
