### PR TITLE
Flip key order instead of global order for backward cursor

### DIFF
--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -198,7 +198,7 @@ func (p *Paginator) buildOrderSQL() string {
 	for i, rule := range p.rules {
 		order := rule.Order
 		if p.isBackward() {
-			order = p.order.flip()
+			order = order.flip()
 		}
 		orders[i] = fmt.Sprintf("%s %s", rule.SQLRepr, order)
 	}


### PR DESCRIPTION
I noticed the results for page back were different when I had a global order different from the key order. For this case, the global ordering was being flipped instead of the key one.