### PR TITLE
Allow replacing NULLs with arbitrary values

### DIFF
--- a/cursor/encoder.go
+++ b/cursor/encoder.go
@@ -9,13 +9,14 @@ import (
 )
 
 // NewEncoder creates cursor encoder
-func NewEncoder(keys ...string) *Encoder {
-	return &Encoder{keys}
+func NewEncoder(keys []string, nullReplacements []interface{}) *Encoder {
+	return &Encoder{keys, nullReplacements}
 }
 
 // Encoder cursor encoder
 type Encoder struct {
-	keys []string
+	keys             []string
+	nullReplacements []interface{}
 }
 
 // Encode encodes model into cursor
@@ -36,7 +37,7 @@ func (e *Encoder) marshalJSON(model interface{}) ([]byte, error) {
 			return nil, ErrInvalidModel
 		}
 		if e.isNilable(f) && f.IsZero() {
-			fields[i] = nil
+			fields[i] = e.nullReplacements[i]
 		} else {
 			fields[i] = util.ReflectValue(f).Interface()
 		}

--- a/cursor/encoder.go
+++ b/cursor/encoder.go
@@ -9,14 +9,13 @@ import (
 )
 
 // NewEncoder creates cursor encoder
-func NewEncoder(keys []string, nullReplacements []interface{}) *Encoder {
-	return &Encoder{keys, nullReplacements}
+func NewEncoder(keys ...string) *Encoder {
+	return &Encoder{keys}
 }
 
 // Encoder cursor encoder
 type Encoder struct {
-	keys             []string
-	nullReplacements []interface{}
+	keys []string
 }
 
 // Encode encodes model into cursor
@@ -37,7 +36,7 @@ func (e *Encoder) marshalJSON(model interface{}) ([]byte, error) {
 			return nil, ErrInvalidModel
 		}
 		if e.isNilable(f) && f.IsZero() {
-			fields[i] = e.nullReplacements[i]
+			fields[i] = nil
 		} else {
 			fields[i] = util.ReflectValue(f).Interface()
 		}

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -131,8 +131,8 @@ func (p *Paginator) setup(db *gorm.DB, dest interface{}) {
 			sqlKey := p.parseSQLKey(dest, rule.Key)
 			rule.SQLRepr = fmt.Sprintf("%s.%s", sqlTable, sqlKey)
 		}
-		if rule.ReplaceNULLWith != nil {
-			rule.SQLRepr = fmt.Sprintf("COALESCE(%s, '%v')", rule.SQLRepr, rule.ReplaceNULLWith)
+		if rule.NULLReplacement != nil {
+			rule.SQLRepr = fmt.Sprintf("COALESCE(%s, '%v')", rule.SQLRepr, rule.NULLReplacement)
 		}
 		if rule.Order == "" {
 			rule.Order = p.order
@@ -185,7 +185,7 @@ func (p *Paginator) decodeCursor(dest interface{}) (result []interface{}, err er
 	// replace null values
 	for i := range result {
 		if isNil(result[i]) {
-			result[i] = p.rules[i].ReplaceNULLWith
+			result[i] = p.rules[i].NULLReplacement
 		}
 	}
 	return

--- a/paginator/paginator_paginate_test.go
+++ b/paginator/paginator_paginate_test.go
@@ -452,8 +452,6 @@ func (s *paginatorSuite) TestPaginateJoinQuery() {
 	s.assertForwardOnly(c)
 }
 
-/* compatibility */
-
 func (s *paginatorSuite) TestPaginateJoinQueryWithAlias() {
 	orders := s.givenOrders(2)
 	// total 6 items
@@ -519,6 +517,54 @@ func (s *paginatorSuite) TestPaginateJoinQueryWithAlias() {
 	s.assertForwardOnly(c)
 }
 
+/* NULL replacement */
+
+func (s *paginatorSuite) TestPaginateReplaceNULL() {
+	s.givenOrders([]order{
+		{ID: 1, Remark: ptrStr("r1")},
+		{ID: 2, Remark: nil},
+		{ID: 3, Remark: ptrStr("r3")},
+		{ID: 4, Remark: nil},
+		{ID: 5, Remark: ptrStr("r5")},
+	})
+
+	cfg := Config{
+		Rules: []Rule{
+			{
+				Key:             "Remark",
+				ReplaceNULLWith: "",
+			},
+			{
+				Key: "ID",
+			},
+		},
+		Limit: 3,
+	}
+
+	var p1 []order
+
+	_, c, _ := New(&cfg).Paginate(s.db, &p1)
+
+	s.assertIDs(p1, 5, 3, 1)
+	s.assertForwardOnly(c)
+
+	var p2 []order
+
+	_, c, _ = New(&cfg, WithAfter(*c.After)).Paginate(s.db, &p2)
+
+	s.assertIDs(p2, 4, 2)
+	s.assertBackwardOnly(c)
+
+	var p3 []order
+
+	_, c, _ = New(&cfg, WithBefore(*c.Before)).Paginate(s.db, &p3)
+
+	s.assertIDs(p3, 5, 3, 1)
+	s.assertForwardOnly(c)
+}
+
+/* compatibility */
+
 func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndKeyOptions() {
 	now := time.Now()
 	s.givenOrders([]order{
@@ -554,7 +600,9 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndKeyOptions() {
 		WithOrder(ASC),
 		WithAfter(anchorCursor),
 	}
+
 	_, optCursor, _ = New(opts...).Paginate(s.db, &optOrders)
+
 	s.assertIDs(optOrders, 4, 5)
 	s.assertBackwardOnly(optCursor)
 
@@ -563,7 +611,9 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndKeyOptions() {
 	p.SetLimit(3)
 	p.SetOrder(ASC)
 	p.SetAfterCursor(anchorCursor)
+
 	_, builderCursor, _ = p.Paginate(s.db, &builderOrders)
+
 	s.assertIDs(builderOrders, 4, 5)
 	s.assertBackwardOnly(builderCursor)
 
@@ -578,7 +628,9 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndKeyOptions() {
 		WithOrder(ASC),
 		WithBefore(anchorCursor),
 	}
+
 	_, optCursor, _ = New(opts...).Paginate(s.db, &optOrders)
+
 	s.assertIDs(optOrders, 1, 2)
 	s.assertForwardOnly(optCursor)
 
@@ -587,7 +639,9 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndKeyOptions() {
 	p.SetLimit(3)
 	p.SetOrder(ASC)
 	p.SetBeforeCursor(anchorCursor)
+
 	_, builderCursor, _ = p.Paginate(s.db, &builderOrders)
+
 	s.assertIDs(builderOrders, 1, 2)
 	s.assertForwardOnly(builderCursor)
 
@@ -606,6 +660,7 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndRuleOptions() {
 	})
 
 	var temp []order
+
 	result, c, err := New(
 		WithKeys("CreatedAt", "ID"),
 		WithLimit(3),
@@ -616,7 +671,6 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndRuleOptions() {
 	if result.Error != nil {
 		s.FailNow(result.Error.Error())
 	}
-
 	anchorCursor := *c.After
 
 	var optOrders, builderOrders []order
@@ -633,7 +687,9 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndRuleOptions() {
 		WithOrder(ASC),
 		WithAfter(anchorCursor),
 	}
+
 	_, optCursor, _ = New(opts...).Paginate(s.db, &optOrders)
+
 	s.assertIDs(optOrders, 4, 5)
 	s.assertBackwardOnly(optCursor)
 
@@ -645,7 +701,9 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndRuleOptions() {
 	p.SetLimit(3)
 	p.SetOrder(ASC)
 	p.SetAfterCursor(anchorCursor)
+
 	_, builderCursor, err = p.Paginate(s.db, &builderOrders)
+
 	s.assertIDs(builderOrders, 4, 5)
 	s.assertBackwardOnly(builderCursor)
 
@@ -663,7 +721,9 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndRuleOptions() {
 		WithOrder(ASC),
 		WithBefore(anchorCursor),
 	}
+
 	_, optCursor, _ = New(opts...).Paginate(s.db, &optOrders)
+
 	s.assertIDs(optOrders, 1, 2)
 	s.assertForwardOnly(optCursor)
 
@@ -675,7 +735,9 @@ func (s *paginatorSuite) TestPaginateConsistencyBetweenBuilderAndRuleOptions() {
 	p.SetLimit(3)
 	p.SetOrder(ASC)
 	p.SetBeforeCursor(anchorCursor)
+
 	_, builderCursor, _ = p.Paginate(s.db, &builderOrders)
+
 	s.assertIDs(builderOrders, 1, 2)
 	s.assertForwardOnly(builderCursor)
 

--- a/paginator/paginator_paginate_test.go
+++ b/paginator/paginator_paginate_test.go
@@ -532,7 +532,7 @@ func (s *paginatorSuite) TestPaginateReplaceNULL() {
 		Rules: []Rule{
 			{
 				Key:             "Remark",
-				ReplaceNULLWith: "",
+				NULLReplacement: "",
 			},
 			{
 				Key: "ID",

--- a/paginator/rule.go
+++ b/paginator/rule.go
@@ -7,7 +7,7 @@ type Rule struct {
 	Key             string
 	Order           Order
 	SQLRepr         string
-	ReplaceNULLWith interface{}
+	NULLReplacement interface{}
 }
 
 func (r *Rule) validate(dest interface{}) (err error) {

--- a/paginator/rule.go
+++ b/paginator/rule.go
@@ -4,9 +4,10 @@ import "github.com/pilagod/gorm-cursor-paginator/v2/internal/util"
 
 // Rule for paginator
 type Rule struct {
-	Key     string
-	Order   Order
-	SQLRepr string
+	Key             string
+	Order           Order
+	SQLRepr         string
+	ReplaceNULLWith interface{}
 }
 
 func (r *Rule) validate(dest interface{}) (err error) {


### PR DESCRIPTION
This PR is proposal to alleviate the issues with the nullable fields. IIUC the current suggestion, as mentioned in the [know limitations](https://github.com/pilagod/gorm-cursor-paginator#known-issues), is to avoid all nullable columns. With the changes in this PR, nullable columns could be allowed as long as they are accompanied by some other columns that make the combination of all columns unique (which I think is currently not possible).

**Main idea**
If `NULL`s are replaced with a user provided value, nullable columns could be included in the cursors. This PR extends the `Rule` definition to allow users to provide what the `NULL` values should be replaced with for the purposes of pagination. Then `NULL`s are replaced with the provided values when making SQL queries and also when encoding the cursors.

With this, also the `NULLS { FIRST | LAST } problems` are somehow alleviated as the user can decide where to put `NULL`s (with the value it provides for replacement).

@pilagod let me know what you think about this proposal. I'd be happy to fix the tests & polish the code more if you think this is a good feature to add.