### PR TITLE
[WIP] Support JSON pagination

### DIFF
--- a/cursor/decoder_test.go
+++ b/cursor/decoder_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"reflect"
+
 	"github.com/stretchr/testify/suite"
 )
 
@@ -18,12 +20,12 @@ type decoderSuite struct {
 /* decode */
 
 func (s *decoderSuite) TestDecodeKeyNotMatchedModel() {
-	_, err := NewDecoder("Key").Decode("cursor", struct{ ID string }{})
+	_, err := NewDecoder([]string{"Key"}, []*reflect.Type{nil}).Decode("cursor", struct{ ID string }{})
 	s.Equal(ErrInvalidModel, err)
 }
 
 func (s *decoderSuite) TestDecodeNonStructModel() {
-	_, err := NewDecoder("Key").Decode("cursor", 123)
+	_, err := NewDecoder([]string{"Key"}, []*reflect.Type{nil}).Decode("cursor", 123)
 	s.Equal(ErrInvalidModel, err)
 }
 
@@ -31,7 +33,7 @@ func (s *decoderSuite) TestDecodeInvalidCursorFormat() {
 	type model struct {
 		Value string
 	}
-	d := NewDecoder("Value")
+	d := NewDecoder([]string{"Value"}, []*reflect.Type{nil})
 
 	// cursor must be a base64 encoded string
 	_, err := d.Decode("123", model{})
@@ -49,19 +51,19 @@ func (s *decoderSuite) TestDecodeInvalidCursorFormat() {
 }
 
 func (s *decoderSuite) TestDecodeInvalidCursorType() {
-	c, _ := NewEncoder("Value").Encode(struct{ Value int }{123})
-	_, err := NewDecoder("Value").Decode(c, struct{ Value string }{})
+	c, _ := NewEncoder([]string{"Value"}, []interface{}{nil}).Encode(struct{ Value int }{123})
+	_, err := NewDecoder([]string{"Value"}, []*reflect.Type{nil}).Decode(c, struct{ Value string }{})
 	s.Equal(ErrInvalidCursor, err)
 }
 
 /* decode struct */
 
 func (s *decoderSuite) TestDecodeStructInvalidModel() {
-	err := NewDecoder("Value").DecodeStruct("123", struct{ ID string }{})
+	err := NewDecoder([]string{"Value"}, []*reflect.Type{nil}).DecodeStruct("123", struct{ ID string }{})
 	s.Equal(ErrInvalidModel, err)
 }
 
 func (s *decoderSuite) TestDecodeStructInvalidCursor() {
-	err := NewDecoder("Value").DecodeStruct("123", struct{ Value string }{})
+	err := NewDecoder([]string{"Value"}, []*reflect.Type{nil}).DecodeStruct("123", struct{ Value string }{})
 	s.Equal(ErrInvalidCursor, err)
 }

--- a/cursor/encoder_test.go
+++ b/cursor/encoder_test.go
@@ -15,14 +15,14 @@ type encoderSuite struct {
 }
 
 func (s *encoderSuite) TestInvalidModel() {
-	e := NewEncoder("ID")
+	e := NewEncoder([]string{"ID"}, []interface{}{nil})
 	_, err := e.Encode(struct{}{})
 	s.Equal(ErrInvalidModel, err)
 }
 
 func (s *encoderSuite) TestInvalidModelFieldType() {
 	// https://stackoverflow.com/questions/33903552/what-input-will-cause-golangs-json-marshal-to-return-an-error
-	e := NewEncoder("ID")
+	e := NewEncoder([]string{"ID"}, []interface{}{nil})
 	_, err := e.Encode(
 		struct {
 			ID chan int
@@ -32,13 +32,13 @@ func (s *encoderSuite) TestInvalidModelFieldType() {
 }
 
 func (s *encoderSuite) TestZeroValue() {
-	e := NewEncoder("ID")
+	e := NewEncoder([]string{"ID"}, []interface{}{nil})
 	_, err := e.Encode(struct{ ID string }{})
 	s.Nil(err)
 }
 
 func (s *encoderSuite) TestZeroValuePtr() {
-	e := NewEncoder("ID")
+	e := NewEncoder([]string{"ID"}, []interface{}{nil})
 	_, err := e.Encode(struct{ ID *string }{})
 	s.Nil(err)
 }

--- a/cursor/encoding_test.go
+++ b/cursor/encoding_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"reflect"
+
 	"github.com/stretchr/testify/suite"
 )
 
@@ -177,18 +179,36 @@ func (multipleModel) Keys() []string {
 	}
 }
 
+func (multipleModel) Types() []*reflect.Type {
+	return []*reflect.Type{
+		nil,
+		nil,
+		nil,
+	}
+}
+
+func (multipleModel) Metas() []interface{} {
+	return []interface{}{
+		nil,
+		nil,
+		nil,
+	}
+}
+
 func (s *encodingSuite) TestMultipleFields() {
 	keys := multipleModel{}.Keys()
+	metas := multipleModel{}.Metas()
+	types := multipleModel{}.Types()
 
 	t := time.Now()
-	c, err := NewEncoder(keys...).Encode(multipleModel{
+	c, err := NewEncoder(keys, metas).Encode(multipleModel{
 		ID:        123,
 		Name:      "Hello",
 		CreatedAt: &t,
 	})
 	s.Nil(err)
 
-	fields, err := NewDecoder(keys...).Decode(c, multipleModel{})
+	fields, err := NewDecoder(keys, types).Decode(c, multipleModel{})
 	s.Nil(err)
 
 	s.Len(fields, 3)
@@ -199,11 +219,13 @@ func (s *encodingSuite) TestMultipleFields() {
 
 func (s *encoderSuite) TestMultipleFieldsWithZeroValue() {
 	keys := multipleModel{}.Keys()
+	metas := multipleModel{}.Metas()
+	types := multipleModel{}.Types()
 
-	c, err := NewEncoder(keys...).Encode(multipleModel{})
+	c, err := NewEncoder(keys, metas).Encode(multipleModel{})
 	s.Nil(err)
 
-	fields, err := NewDecoder(keys...).Decode(c, multipleModel{})
+	fields, err := NewDecoder(keys, types).Decode(c, multipleModel{})
 	s.Nil(err)
 
 	s.Equal(0, fields[0])
@@ -215,9 +237,11 @@ func (s *encoderSuite) TestMultipleFieldsWithZeroValue() {
 
 func (s *encodingSuite) TestMultipleFieldsToStruct() {
 	keys := multipleModel{}.Keys()
+	metas := multipleModel{}.Metas()
+	types := multipleModel{}.Types()
 
 	t := time.Now()
-	c, err := NewEncoder(keys...).Encode(multipleModel{
+	c, err := NewEncoder(keys, metas).Encode(multipleModel{
 		ID:        123,
 		Name:      "Hello",
 		CreatedAt: &t,
@@ -225,7 +249,7 @@ func (s *encodingSuite) TestMultipleFieldsToStruct() {
 	s.Nil(err)
 
 	var model multipleModel
-	err = NewDecoder(keys...).DecodeStruct(c, &model)
+	err = NewDecoder(keys, types).DecodeStruct(c, &model)
 	s.Nil(err)
 
 	s.Equal(123, model.ID)
@@ -235,12 +259,14 @@ func (s *encodingSuite) TestMultipleFieldsToStruct() {
 
 func (s *encoderSuite) TestMultipleFieldsToStructWithZeroValue() {
 	keys := multipleModel{}.Keys()
+	metas := multipleModel{}.Metas()
+	types := multipleModel{}.Types()
 
-	c, err := NewEncoder(keys...).Encode(multipleModel{})
+	c, err := NewEncoder(keys, metas).Encode(multipleModel{})
 	s.Nil(err)
 
 	var model multipleModel
-	err = NewDecoder(keys...).DecodeStruct(c, &model)
+	err = NewDecoder(keys, types).DecodeStruct(c, &model)
 	s.Nil(err)
 
 	s.Equal(0, model.ID)
@@ -249,15 +275,15 @@ func (s *encoderSuite) TestMultipleFieldsToStructWithZeroValue() {
 }
 
 func (s *encodingSuite) encodeValue(v interface{}) (string, error) {
-	return NewEncoder("Value").Encode(v)
+	return NewEncoder([]string{"Value"}, []interface{}{nil}).Encode(v)
 }
 
 func (s *encodingSuite) encodeValuePtr(v interface{}) (string, error) {
-	return NewEncoder("ValuePtr").Encode(v)
+	return NewEncoder([]string{"ValuePtr"}, []interface{}{nil}).Encode(v)
 }
 
 func (s *encodingSuite) decodeValue(m interface{}, c string) (interface{}, error) {
-	fields, err := NewDecoder("Value").Decode(c, m)
+	fields, err := NewDecoder([]string{"Value"}, []*reflect.Type{nil}).Decode(c, m)
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +294,7 @@ func (s *encodingSuite) decodeValue(m interface{}, c string) (interface{}, error
 }
 
 func (s *encodingSuite) decodeValuePtr(m interface{}, c string) (interface{}, error) {
-	fields, err := NewDecoder("ValuePtr").Decode(c, m)
+	fields, err := NewDecoder([]string{"ValuePtr"}, []*reflect.Type{nil}).Decode(c, m)
 	if err != nil {
 		return nil, err
 	}

--- a/interfaces/types.go
+++ b/interfaces/types.go
@@ -1,0 +1,8 @@
+package interfaces
+
+// CustomTypePaginator is an interface that custom types need to implement
+// in order to allow pagination over fields inside custom types.
+type CustomTypePaginator interface {
+	// GetCustomTypeValue returns the value corresponding to the meta attribute inside the custom type.
+	GetCustomTypeValue(meta interface{}) interface{}
+}

--- a/paginator/rule.go
+++ b/paginator/rule.go
@@ -1,6 +1,10 @@
 package paginator
 
-import "github.com/pilagod/gorm-cursor-paginator/v2/internal/util"
+import (
+	"reflect"
+
+	"github.com/pilagod/gorm-cursor-paginator/v2/internal/util"
+)
 
 // Rule for paginator
 type Rule struct {
@@ -8,6 +12,14 @@ type Rule struct {
 	Order           Order
 	SQLRepr         string
 	NULLReplacement interface{}
+	CustomType      *CustomType
+}
+
+// CustomType for paginator. It provides extra info needed to paginate across custom types (e.g. JSON)
+type CustomType struct {
+	Meta    interface{}
+	Type    reflect.Type
+	SQLType string
 }
 
 func (r *Rule) validate(dest interface{}) (err error) {


### PR DESCRIPTION
Fixes #42.

### Description
This is a WIP implementation of enabling pagination across data inside JSON columns. @pilagod I wanted to get your thoughts on this to see if this is something you are comfortable proceeding with. Please let me know 🙏 

If we are happy to proceed, I would add the tests for the new functionality and document it as well in the readme.

### How to test

#### 1. Define the Custom Type
 First we need to define our type for JSON which also implements the `CustomTypePaginator` interface. Something like this should do:

```go
import (
	"gorm.io/datatypes"
)

type MyJSON struct {
	datatypes.JSON
}

func (j MyJSON) GetCustomTypeValue(meta interface{}) interface{} {
	// The decoding & mapping logic should be implemented by custom type provider
	d := map[string]interface{}{}
	err := json.Unmarshal(j.JSON, &d)
	if err != nil {
		panic("TODO")
	}

	item := d[meta.(string)]

         // remove quotes from string for SQL comparisons
	if s, ok := item.(string); ok {
		return strings.ReplaceAll(s, "\"", "")
	}

	return item
}
```

#### 2. Define GORM model & data structure
Let our struct be like this:

```go
type Item struct {
	ID     string       `gorm:"primaryKey,column:id" json:"id"`
	Value  string       `gorm:"column:value" json:"value"`
	Number float64      `gorm:"column:number" json:"number"`
	Data   MyJSONB      `gorm:"column:data" json:"data"`
}
```
 And let the data field in the DB contains JSONs like this:
 ```json
{
    "k1": "a",
    "k2": 1.0
}
 ```
 
 #### 3. Define pagination rules
To paginate on `k1` ascending, we would need a rule like this:

```go
rule = paginator.Rule{
	Key:             "Data",
	Order:           paginator.ASC,
	SQLRepr:         "data #>> '{k1}'",
	NULLReplacement: "",
	CustomType: &paginator.CustomType{
		Meta:    "k1",
		Type:    reflect.PtrTo(reflect.TypeOf("")),
		SQLType: "text",
	},
}
```

To paginate on `k2` descending, we would need a rule like this:

```go
rule = paginator.Rule{
	Key:             "Data",
	Order:           paginator.DESC,
	SQLRepr:         "data #>> '{k2}'",
	NULLReplacement: 0.0,
	CustomType: &paginator.CustomType{
		Meta:    "k2",
		Type:    reflect.PtrTo(reflect.TypeOf(1.0)),
		SQLType: "numeric",
	},
}
```

### Concerns

1. `CustomType` struct needs a few extra information. In order to be able to type cast in the encoder, decoder and SQL, we need to provide:
    1. `meta`: the meta attribute path on the custom type objects (in case of JSONs, this would be the key)
    1. `type`: Golang type for the decoded to be able to cast it to a correct type
    1. `SQLType`: to make type casting in SQL. By default, the when you use JSON operators like `#>>` the returned type will be JSON (see [the note](https://www.postgresql.org/docs/9.4/functions-json.html) in the docs), hence in order for comparisons to work correctly we need to type cast it to the correct type.



