### PR TITLE
use schema DBName to parse SQLKey

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: unit-test-ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  run-test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11-alpine
+        ports:
+          - 8765:5432
+        env:
+          POSTGRES_DB: test
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - name: setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.14'
+      - name: test
+        run: go test ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   run-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ 1.14, 1.15 ]
     services:
       postgres:
         image: postgres:11-alpine
@@ -27,9 +30,9 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v3
-      - name: setup go
+      - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.14'
-      - name: test
+          go-version: ${{ matrix.go-version }}
+      - name: Run tests
         run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/pilagod/gorm-cursor-paginator/v2
 go 1.14
 
 require (
-	github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7
 	github.com/stretchr/testify v1.8.0
 	gorm.io/driver/postgres v1.0.8
 	gorm.io/driver/sqlite v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7 h1:ux/56T2xqZO/3cP1I2F86qpeoYPCOzk+KF/UH/Ar+lk=
-github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
@@ -112,11 +110,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
@@ -176,7 +172,6 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/util/model.go
+++ b/internal/util/model.go
@@ -7,8 +7,7 @@ import (
 
 func ParseSchema(db *gorm.DB, model interface{}) (*schema.Schema, error) {
 	stmt := &gorm.Statement{DB: db}
-	err := stmt.Parse(model)
-	if err != nil {
+	if err := stmt.Parse(model); err != nil {
 		return nil, err
 	}
 	return stmt.Schema, nil

--- a/internal/util/model.go
+++ b/internal/util/model.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
+func ParseSchema(db *gorm.DB, model interface{}) (*schema.Schema, error) {
+	stmt := &gorm.Statement{DB: db}
+	err := stmt.Parse(model)
+	if err != nil {
+		return nil, err
+	}
+	return stmt.Schema, nil
+}

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -70,8 +70,7 @@ func (p *Paginator) Paginate(db *gorm.DB, dest interface{}) (result *gorm.DB, c 
 	if err = p.validate(db, dest); err != nil {
 		return
 	}
-	err = p.setup(db, dest)
-	if err != nil {
+	if err = p.setup(db, dest); err != nil {
 		return
 	}
 	fields, err := p.decodeCursor(dest)

--- a/paginator/paginator_test.go
+++ b/paginator/paginator_test.go
@@ -97,7 +97,7 @@ func (s *paginatorSuite) SetupSuite() {
 	if err != nil {
 		s.FailNow(err.Error())
 	}
-	s.db = db
+	s.db = db.Debug()
 	s.db.AutoMigrate(&order{}, &item{})
 }
 

--- a/paginator/rule.go
+++ b/paginator/rule.go
@@ -1,6 +1,7 @@
 package paginator
 
 import (
+	"gorm.io/gorm"
 	"reflect"
 
 	"github.com/pilagod/gorm-cursor-paginator/v2/internal/util"
@@ -22,8 +23,10 @@ type CustomType struct {
 	Type reflect.Type
 }
 
-func (r *Rule) validate(dest interface{}) (err error) {
-	if _, ok := util.ReflectType(dest).FieldByName(r.Key); !ok {
+func (r *Rule) validate(db *gorm.DB, dest interface{}) (err error) {
+	if schema, err := util.ParseSchema(db, dest); err != nil {
+		return ErrInvalidModel
+	} else if f := schema.LookUpField(r.Key); f == nil {
 		return ErrInvalidModel
 	}
 	if r.Order != "" {


### PR DESCRIPTION
 SQLKey is hard coded as snake case, but GORM has configuration `NamingStrategy`
This pr use `schema.LookUpField(key).DBName` to get database name of key field

see https://gorm.io/docs/gorm_config.html#NamingStrategy 