### PR TITLE
Cast `NULLReplacement` when `SQLType` is specified

### DIFF
--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -135,11 +135,9 @@ func (p *Paginator) setup(db *gorm.DB, dest interface{}) error {
 		}
 
 		if rule.NULLReplacement != nil {
-			var nullReplacement string
+			nullReplacement := fmt.Sprintf("'%v'", rule.NULLReplacement)
 			if rule.SQLType != nil {
-				nullReplacement = fmt.Sprintf("CAST('%v' as %s)", rule.NULLReplacement, *rule.SQLType)
-			} else {
-				nullReplacement = fmt.Sprintf("'%v'", rule.NULLReplacement)
+				nullReplacement = fmt.Sprintf("CAST(%s as %s)", nullReplacement, *rule.SQLType)
 			}
 			rule.SQLRepr = fmt.Sprintf("COALESCE(%s, %s)", rule.SQLRepr, nullReplacement)
 		}

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -133,8 +133,15 @@ func (p *Paginator) setup(db *gorm.DB, dest interface{}) error {
 			sqlKey := p.parseSQLKey(db, dest, rule.Key)
 			rule.SQLRepr = fmt.Sprintf("%s.%s", sqlTable, sqlKey)
 		}
+
 		if rule.NULLReplacement != nil {
-			rule.SQLRepr = fmt.Sprintf("COALESCE(%s, '%v')", rule.SQLRepr, rule.NULLReplacement)
+			var nullReplacement string
+			if rule.SQLType != nil {
+				nullReplacement = fmt.Sprintf("CAST('%v' as %s)", rule.NULLReplacement, *rule.SQLType)
+			} else {
+				nullReplacement = fmt.Sprintf("'%v'", rule.NULLReplacement)
+			}
+			rule.SQLRepr = fmt.Sprintf("COALESCE(%s, %s)", rule.SQLRepr, nullReplacement)
 		}
 		// cast to the underlying SQL type
 		if rule.SQLType != nil {


### PR DESCRIPTION
Some SQL dialects (like Clickhouse) do not automatically cast strings `'%v'` to the appropriate column type, resulting in an error when this is attempted. This causes an error when using a `paginator.Rule` on a non-string type column.

To circumvent this issue, the fix here explicitly casts the `NULLReplacement` value to the provided `SQLType`