### PR TITLE
Support NULL value replacement for custom types

### DIFF
--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -163,6 +163,14 @@ func isNil(i interface{}) bool {
 	if i == nil {
 		return true
 	}
+	// for custom types, evaluate isNil on the underlying value
+	if ct, ok := i.(cursor.CustomType); ok {
+		val, err := ct.GetCustomTypeValue(i)
+		if err != nil {
+			return false
+		}
+		return isNil(val)
+	}
 	switch reflect.TypeOf(i).Kind() {
 	// reflect.Array is intentionally omitted since calling IsNil() on the value
 	// of an array will panic

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -184,19 +184,12 @@ func (p *Paginator) decodeCursor(dest interface{}) (result []interface{}, err er
 	}
 	// replace null values
 	for i := range result {
-		var isNullValue bool
+		value := result[i]
 		// for custom types, evaluate isNil on the underlying value
 		if ct, ok := result[i].(cursor.CustomType); ok && p.rules[i].CustomType != nil {
-			val, valErr := ct.GetCustomTypeValue(p.rules[i].CustomType.Meta)
-			if valErr != nil {
-				err = valErr
-			}
-			isNullValue = isNil(val)
-		} else {
-			isNullValue = isNil(result[i])
+			value, err = ct.GetCustomTypeValue(p.rules[i].CustomType.Meta)
 		}
-
-		if isNullValue {
+		if isNil(value) {
 			result[i] = p.rules[i].NULLReplacement
 		}
 	}

--- a/paginator/paginator_test.go
+++ b/paginator/paginator_test.go
@@ -24,10 +24,11 @@ func TestPaginator(t *testing.T) {
 /* models */
 
 type order struct {
-	ID        int       `gorm:"primaryKey"`
-	Remark    *string   `gorm:"type:varchar(30)"`
-	CreatedAt time.Time `gorm:"type:timestamp;not null"`
-	Data      JSON      `gorm:"type:jsonb"`
+	ID          int        `gorm:"primaryKey"`
+	Remark      *string    `gorm:"type:varchar(30)"`
+	CreatedAt   time.Time  `gorm:"type:timestamp;not null"`
+	Data        JSON       `gorm:"type:jsonb"`
+	Description NullString `gorm:"type:varchar(30)"`
 }
 
 type item struct {


### PR DESCRIPTION
This PR aims to add support for NULL value replacement in custom types. Builds upon #39 and #44.

### Current issue 
The issue that I came across with the current implementation is that when the pagination cursor includes `null` for a custom type, that value is not properly replaced with the `NullReplacement` value. The reason is that the Go-representation of the cursor value is not nil, but a custom type object (with an underlying value of nil).

This in turn causes the pagination WHERE clause to compare the COALESCEd values of the target column with an unreplaced NULL, e.g. `WHERE COALESCE(my_attr, '') > NULL`.

### Implementation
The change in this PR specifically handles custom types in the `isNil` function so that for custom types we evaluate `isNil` on the underlying value retrieved by `GetCustomTypeValue` instead of on the object itself.

### Test
In order to construct a test, I added a custom type as an alias of [`sql.NullString`](https://pkg.go.dev/database/sql#NullString), implemented the necessary methods on this type, and added a new field to the `order` struct. I guess this is a bit clumsy, in case you have any ideas about how to construct such a test more compactly, please let me know :)
In the test itself, we have a primary pagination rule on "Remark" and a secondary rule on the new "Description" field so that the NULL element (ID 2) appears in the cursor causing the described problem.
