### PR TITLE
feat: Add optimization feature for composite cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ For example, let us assume we have the following code:
 ```go
 paginator.New(
     paginator.WithKeys([]string{"CreatedAt", "ID"}),
-    paginate.WithAfter(after),
-    paginate.WithLimit(3),
+    paginator.WithAfter(after),
+    paginator.WithLimit(3),
 ).Paginate(db, &result)
 ```
 
@@ -220,9 +220,9 @@ Even if we index our table on `(created_at, id)` columns, some database engines 
 ```go
 paginator.New(
     paginator.WithKeys([]string{"CreatedAt", "ID"}),
-    paginate.WithAfter(after),
-    paginate.WithLimit(3),
-    paginate.WithTupleCmp(paginate.ENABLED),
+    paginator.WithAfter(after),
+    paginator.WithLimit(3),
+    paginator.WithTupleCmp(paginate.ENABLED),
 ).Paginate(db, &result)
 ```
 
@@ -236,7 +236,7 @@ ORDER BY orders.created_at ASC, orders.id ASC
    LIMIT 4
 ```
 
-In this case, if we have index on `(created_at, id)` columns, most DB angines will know how to optimize this query into a simple initial index lookup + scan, making cursor overhead neglible.
+In this case, if we have index on `(created_at, id)` columns, most DB engines will know how to optimize this query into a simple initial index lookup + scan, making cursor overhead negligible.
 
 ### paginator.Rule
 

--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ Default options used by paginator when not specified:
 
 - `Order`: `paginator.DESC`
 
-- `TupleCmp`: `paginator.DISABLED`
+- `AllowTupleCmp`: `paginator.FALSE`
 
-When cursor uses more than one key/rule, paginator instances by default generate SQL that is compatible with almost all database management systems. But this query can be very inefficient and can result in a lot of database scans even when proper indices are in place. By enabling the `TupleCmp` option, paginator will emit a slightly different SQL query when all cursor keys are ordered in the same way.
+When cursor uses more than one key/rule, paginator instances by default generate SQL that is compatible with almost all database management systems. But this query can be very inefficient and can result in a lot of database scans even when proper indices are in place. By enabling the `AllowTupleCmp` option, paginator will emit a slightly different SQL query when all cursor keys are ordered in the same way.
 
 For example, let us assume we have the following code:
 
@@ -222,7 +222,7 @@ paginator.New(
     paginator.WithKeys([]string{"CreatedAt", "ID"}),
     paginator.WithAfter(after),
     paginator.WithLimit(3),
-    paginator.WithTupleCmp(paginate.ENABLED),
+    paginator.WithAllowTupleCmp(paginate.TRUE),
 ).Paginate(db, &result)
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: "3"
 services: 
   postgres:
     image: postgres:11-alpine
+    command:
+      - -c
+      - log_statement=all
     ports:
       - 8765:5432
     environment: 

--- a/paginator/option.go
+++ b/paginator/option.go
@@ -1,9 +1,17 @@
 package paginator
 
+type Flag string
+
+const (
+	ENABLED  Flag = "ENABLED"
+	DISABLED Flag = "DISABLED"
+)
+
 var defaultConfig = Config{
-	Keys:  []string{"ID"},
-	Limit: 10,
-	Order: DESC,
+	Keys:     []string{"ID"},
+	Limit:    10,
+	Order:    DESC,
+	TupleCmp: DISABLED,
 }
 
 // Option for paginator
@@ -13,12 +21,13 @@ type Option interface {
 
 // Config for paginator
 type Config struct {
-	Rules  []Rule
-	Keys   []string
-	Limit  int
-	Order  Order
-	After  string
-	Before string
+	Rules    []Rule
+	Keys     []string
+	Limit    int
+	Order    Order
+	After    string
+	Before   string
+	TupleCmp Flag
 }
 
 // Apply applies config to paginator
@@ -41,6 +50,9 @@ func (c *Config) Apply(p *Paginator) {
 	}
 	if c.Before != "" {
 		p.SetBeforeCursor(c.Before)
+	}
+	if c.TupleCmp != "" {
+		p.SetAllowTupleCmp(c.TupleCmp == ENABLED)
 	}
 }
 
@@ -83,5 +95,12 @@ func WithAfter(c string) Option {
 func WithBefore(c string) Option {
 	return &Config{
 		Before: c,
+	}
+}
+
+// WithAllowTupleCmp enables tuple comparison optimization
+func WithTupleCmp(flag Flag) Option {
+	return &Config{
+		TupleCmp: flag,
 	}
 }

--- a/paginator/option.go
+++ b/paginator/option.go
@@ -3,15 +3,15 @@ package paginator
 type Flag string
 
 const (
-	ENABLED  Flag = "ENABLED"
-	DISABLED Flag = "DISABLED"
+	TRUE  Flag = "TRUE"
+	FALSE Flag = "FALSE"
 )
 
 var defaultConfig = Config{
-	Keys:     []string{"ID"},
-	Limit:    10,
-	Order:    DESC,
-	TupleCmp: DISABLED,
+	Keys:          []string{"ID"},
+	Limit:         10,
+	Order:         DESC,
+	AllowTupleCmp: FALSE,
 }
 
 // Option for paginator
@@ -21,13 +21,13 @@ type Option interface {
 
 // Config for paginator
 type Config struct {
-	Rules    []Rule
-	Keys     []string
-	Limit    int
-	Order    Order
-	After    string
-	Before   string
-	TupleCmp Flag
+	Rules         []Rule
+	Keys          []string
+	Limit         int
+	Order         Order
+	After         string
+	Before        string
+	AllowTupleCmp Flag
 }
 
 // Apply applies config to paginator
@@ -51,8 +51,8 @@ func (c *Config) Apply(p *Paginator) {
 	if c.Before != "" {
 		p.SetBeforeCursor(c.Before)
 	}
-	if c.TupleCmp != "" {
-		p.SetAllowTupleCmp(c.TupleCmp == ENABLED)
+	if c.AllowTupleCmp != "" {
+		p.SetAllowTupleCmp(c.AllowTupleCmp == TRUE)
 	}
 }
 
@@ -99,8 +99,8 @@ func WithBefore(c string) Option {
 }
 
 // WithAllowTupleCmp enables tuple comparison optimization
-func WithTupleCmp(flag Flag) Option {
+func WithAllowTupleCmp(flag Flag) Option {
 	return &Config{
-		TupleCmp: flag,
+		AllowTupleCmp: flag,
 	}
 }

--- a/paginator/paginator_paginate_test.go
+++ b/paginator/paginator_paginate_test.go
@@ -15,7 +15,7 @@ func (s *paginatorSuite) TestPaginateDefaultOptions() {
 	// * Key: ID
 	// * Limit: 10
 	// * Order: DESC
-	// * TupleCmp: DISABLED
+	// * AllowTupleCmp: FALSE
 
 	var p1 []order
 	_, c, _ := New().Paginate(s.db, &p1)
@@ -226,9 +226,9 @@ func (s *paginatorSuite) TestPaginateMultipleKeysTupleCmp() {
 	})
 
 	cfg := Config{
-		Keys:     []string{"CreatedAt", "ID"},
-		Limit:    2,
-		TupleCmp: ENABLED,
+		Keys:          []string{"CreatedAt", "ID"},
+		Limit:         2,
+		AllowTupleCmp: TRUE,
 	}
 
 	var p1 []order


### PR DESCRIPTION
Current implementation of pagination on composite cursors is rather inefficient on large tables even in the presence of index. Changes in this commit add an optimization option that causes paginator to emit a bit different WHERE condition that query engines have an easier time optimizing.

We kept changes backward-compatible. We need to opt-in to get the new feature enabled.