### PR TITLE
Fix slice encoding

### DIFF
--- a/cursor/encoder_test.go
+++ b/cursor/encoder_test.go
@@ -51,3 +51,9 @@ func (s *encoderSuite) TestZeroValuePtr() {
 	_, err := e.Encode(struct{ ID *string }{})
 	s.Nil(err)
 }
+
+func (s *encoderSuite) TestSliceValue() {
+	e := NewEncoder([]EncoderField{{Key: "Slice"}})
+	_, err := e.Encode(struct{ Slice []string }{Slice: []string{"value"}})
+	s.Nil(err)
+}

--- a/cursor/encoding_test.go
+++ b/cursor/encoding_test.go
@@ -164,6 +164,28 @@ func (s *encodingSuite) TestStructPtr() {
 	s.Equal(sv, *(v.(*structValue)))
 }
 
+/* slice */
+
+type sliceModel struct {
+	Value    []byte
+	ValuePtr *[]byte
+}
+
+func (s *encodingSuite) TestSlice() {
+	c, _ := s.encodeValue(sliceModel{
+		Value: []byte("123"),
+	})
+	v, _ := s.decodeValue(sliceModel{}, c)
+	s.Equal([]byte("123"), v)
+}
+
+func (s *encodingSuite) TestSlicePtr() {
+	sv := []byte("123")
+	c, _ := s.encodeValuePtr(sliceModel{ValuePtr: &sv})
+	v, _ := s.decodeValuePtr(sliceModel{}, c)
+	s.Equal(sv, *(v.(*[]byte)))
+}
+
 /* multiple */
 
 type multipleModel struct {

--- a/internal/util/reflect.go
+++ b/internal/util/reflect.go
@@ -4,13 +4,13 @@ import (
 	"reflect"
 )
 
-// ReflectValue returns reflect value underlying given value, unwrapping pointer and slice
+// ReflectValue returns reflect value underlying given value, unwrapping pointer
 func ReflectValue(v interface{}) reflect.Value {
 	rv, ok := v.(reflect.Value)
 	if !ok {
 		rv = reflect.ValueOf(v)
 	}
-	for rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Slice {
+	for rv.Kind() == reflect.Ptr {
 		rv = rv.Elem()
 	}
 	return rv


### PR DESCRIPTION
Encoding a field that is a slice will currently panic due to `Elem()` being called on a slice in `util.ReflectValue`. `reflect.Value` only allows for `Elem()` to be called on interface or pointer values and will [panic otherwise](https://cs.opensource.google/go/go/+/refs/tags/go1.22.4:src/reflect/value.go;l=1228). So this just removes slice from being included in the check to unwrap and adds in a test to validate that encoding the slice is successful.
