### PR TITLE
feat: add support for custom encoder/decoder implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A paginator doing cursor-based pagination based on [GORM](https://github.com/go-
 - GORM `column` tag supported.
 - Error handling enhancement.
 - Exporting `cursor` module for advanced usage.
+- Implement custom codec for cursor encoding/decoding.
 
 ## Installation
 
@@ -133,46 +134,66 @@ We first need to create a `paginator.Paginator` for `User`, here are some useful
 
 4. By default the library encodes cursors with `base64`. If a custom encoding/decoding implementation is required, this can be implemented and passed as part of the configuration:
 
-    ```go
-    func CreateUserPaginator(/* ... */) {
-        p := paginator.New(
-            &paginator.Config{
-                Rules: []paginator.Rule{
-                    {
-                        Key: "ID",
-                    },
-                    {
-                        Key: "JoinedAt",
-                        Order: paginator.DESC,
-                        SQLRepr: "users.created_at",
-                        NULLReplacement: "1970-01-01",
-                    },
-                },
-                Limit: 10,
-                // supply a custom implementation for the encoder/decoder 
-                CursorCodecFactory: NewCustomCodec,
-                // Order here will apply to keys without order specified.
-                // In this example paginator will order by "ID" ASC, "JoinedAt" DESC.
-                Order: paginator.ASC, 
-            },
-        )
-        // ...
-        return p
-    }
-    ```
 
-Where the `NewCustomCodec` parameter is a function with the following signature:
+First implement your custom codec such that it conforms to the `CursorCodec` interface:
 
-```go
-func(encoderFields []cursor.EncoderField, decoderFields []cursor.DecoderField) CursorCodec
-```
-
-Returning an implementation conforming to the `CursorCodec` interface:
 
 ```go
 type CursorCodec interface {
-    Encode(model interface{}) (string, error)
-    Decode(cursor string, model interface{}) (fields []interface{}, err error)
+    // Encode encodes model fields into cursor
+    Encode(
+        fields []pc.EncoderField,
+        model interface{},
+    ) (string, error)
+
+    // Decode decodes cursor into model fields
+    Decode(
+        fields []pc.DecoderField,
+        cursor string,
+        model interface{},
+    ) ([]interface{}, error)
+}
+    
+type customCodec struct {}
+
+func (cc *CustomCodec) Encode(fields []pc.EncoderField, model interface{}) (string, error) {
+    ...
+}
+
+func (cc *CustomCodec) Decode(fields []pc.DecoderField, cursor string, model interface{}) ([]interface{}, error) {
+    ...
+}
+```
+
+Then pass an instance of your codec during initialisation:
+
+```go
+func CreateUserPaginator(/* ... */) {
+	codec := &customCodec{}
+	
+	p := paginator.New(
+        &paginator.Config{
+            Rules: []paginator.Rule{
+                {
+                    Key: "ID",
+                },
+                {
+                    Key: "JoinedAt",
+                    Order: paginator.DESC,
+                    SQLRepr: "users.created_at",
+                    NULLReplacement: "1970-01-01",
+                },
+            },
+            Limit: 10,
+            // supply a custom implementation for the encoder/decoder 
+            CursorCodec: codec,
+            // Order here will apply to keys without order specified.
+            // In this example paginator will order by "ID" ASC, "JoinedAt" DESC.
+            Order: paginator.ASC, 
+        },
+    )
+    // ...
+    return p
 }
 ```
 

--- a/paginator/cursor.go
+++ b/paginator/cursor.go
@@ -1,6 +1,44 @@
 package paginator
 
-import "github.com/pilagod/gorm-cursor-paginator/v2/cursor"
+import (
+	pc "github.com/pilagod/gorm-cursor-paginator/v2/cursor"
+)
 
 // Cursor re-exports cursor.Cursor
-type Cursor = cursor.Cursor
+type Cursor = pc.Cursor
+
+// CursorCodec encodes/decodes cursor
+type CursorCodec interface {
+	// Encode encodes model fields into cursor
+	Encode(
+		fields []pc.EncoderField,
+		model interface{},
+	) (string, error)
+
+	// Decode decodes cursor into model fields
+	Decode(
+		fields []pc.DecoderField,
+		cursor string,
+		model interface{},
+	) ([]interface{}, error)
+}
+
+// JSONCursorCodec encodes/decodes cursor in JSON format
+type JSONCursorCodec struct{}
+
+// Encode encodes model fields into JSON format cursor
+func (*JSONCursorCodec) Encode(
+	fields []pc.EncoderField,
+	model interface{},
+) (string, error) {
+	return pc.NewEncoder(fields).Encode(model)
+}
+
+// Decode decodes JSON format cursor into model fields
+func (*JSONCursorCodec) Decode(
+	fields []pc.DecoderField,
+	cursor string,
+	model interface{},
+) ([]interface{}, error) {
+	return pc.NewDecoder(fields).Decode(cursor, model)
+}

--- a/paginator/option.go
+++ b/paginator/option.go
@@ -1,5 +1,7 @@
 package paginator
 
+import "github.com/pilagod/gorm-cursor-paginator/v2/cursor"
+
 type Flag string
 
 const (
@@ -28,6 +30,8 @@ type Config struct {
 	After         string
 	Before        string
 	AllowTupleCmp Flag
+
+	CursorCodecFactory func(encoderFields []cursor.EncoderField, decoderFields []cursor.DecoderField) CursorCodec
 }
 
 // Apply applies config to paginator
@@ -53,6 +57,10 @@ func (c *Config) Apply(p *Paginator) {
 	}
 	if c.AllowTupleCmp != "" {
 		p.SetAllowTupleCmp(c.AllowTupleCmp == TRUE)
+	}
+
+	if c.CursorCodecFactory != nil {
+		p.SetCursorCodecFactory(c.CursorCodecFactory)
 	}
 }
 

--- a/paginator/option.go
+++ b/paginator/option.go
@@ -1,7 +1,5 @@
 package paginator
 
-import "github.com/pilagod/gorm-cursor-paginator/v2/cursor"
-
 type Flag string
 
 const (
@@ -14,6 +12,7 @@ var defaultConfig = Config{
 	Limit:         10,
 	Order:         DESC,
 	AllowTupleCmp: FALSE,
+	CursorCodec:   &JSONCursorCodec{},
 }
 
 // Option for paginator
@@ -30,8 +29,7 @@ type Config struct {
 	After         string
 	Before        string
 	AllowTupleCmp Flag
-
-	CursorCodecFactory func(encoderFields []cursor.EncoderField, decoderFields []cursor.DecoderField) CursorCodec
+	CursorCodec   CursorCodec
 }
 
 // Apply applies config to paginator
@@ -58,9 +56,8 @@ func (c *Config) Apply(p *Paginator) {
 	if c.AllowTupleCmp != "" {
 		p.SetAllowTupleCmp(c.AllowTupleCmp == TRUE)
 	}
-
-	if c.CursorCodecFactory != nil {
-		p.SetCursorCodecFactory(c.CursorCodecFactory)
+	if c.CursorCodec != nil {
+		p.SetCursorCodec(c.CursorCodec)
 	}
 }
 
@@ -110,5 +107,12 @@ func WithBefore(c string) Option {
 func WithAllowTupleCmp(flag Flag) Option {
 	return &Config{
 		AllowTupleCmp: flag,
+	}
+}
+
+// WithCursorCodec configures custom cursor codec
+func WithCursorCodec(codec CursorCodec) Option {
+	return &Config{
+		CursorCodec: codec,
 	}
 }


### PR DESCRIPTION
This pull request adds the ability to provider custom cursor encoder/decoder implementations.

It is a non-breaking change, adding two new config options `CursorEncoderFactory` and `CursorDecoderFactory` that if defined will be used for encoding/decoding the cursor.

Internally the library has been slightly modified to use interfaces for encoding/decoding as opposed to using the hardcoded cursor package. If no implementation is provided the existing cursor implementation is used.