### PR TITLE
Add support for cursor direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A paginator doing cursor-based pagination based on [GORM](https://github.com/go-
 - GORM `column` tag supported.
 - Error handling enhancement.
 - Exporting `cursor` module for advanced usage.
+- Implement custom codec for cursor encoding/decoding.
 
 ## Installation
 
@@ -133,46 +134,66 @@ We first need to create a `paginator.Paginator` for `User`, here are some useful
 
 4. By default the library encodes cursors with `base64`. If a custom encoding/decoding implementation is required, this can be implemented and passed as part of the configuration:
 
-    ```go
-    func CreateUserPaginator(/* ... */) {
-        p := paginator.New(
-            &paginator.Config{
-                Rules: []paginator.Rule{
-                    {
-                        Key: "ID",
-                    },
-                    {
-                        Key: "JoinedAt",
-                        Order: paginator.DESC,
-                        SQLRepr: "users.created_at",
-                        NULLReplacement: "1970-01-01",
-                    },
-                },
-                Limit: 10,
-                // supply a custom implementation for the encoder/decoder 
-                CursorCodecFactory: NewCustomCodec,
-                // Order here will apply to keys without order specified.
-                // In this example paginator will order by "ID" ASC, "JoinedAt" DESC.
-                Order: paginator.ASC, 
-            },
-        )
-        // ...
-        return p
-    }
-    ```
 
-Where the `NewCustomCodec` parameter is a function with the following signature:
+First implement your custom codec such that it conforms to the `CursorCodec` interface:
 
-```go
-func(encoderFields []cursor.EncoderField, decoderFields []cursor.DecoderField) CursorCodec
-```
-
-Returning an implementation conforming to the `CursorCodec` interface:
 
 ```go
 type CursorCodec interface {
-    Encode(model interface{}) (string, error)
-    Decode(cursor string, model interface{}) (fields []interface{}, err error)
+    // Encode encodes model fields into cursor
+    Encode(
+        fields []pc.EncoderField,
+        model interface{},
+    ) (string, error)
+
+    // Decode decodes cursor into model fields
+    Decode(
+        fields []pc.DecoderField,
+        cursor string,
+        model interface{},
+    ) ([]interface{}, error)
+}
+    
+type customCodec struct {}
+
+func (cc *CustomCodec) Encode(fields []pc.EncoderField, model interface{}) (string, error) {
+    ...
+}
+
+func (cc *CustomCodec) Decode(fields []pc.DecoderField, cursor string, model interface{}) ([]interface{}, error) {
+    ...
+}
+```
+
+Then pass an instance of your codec during initialisation:
+
+```go
+func CreateUserPaginator(/* ... */) {
+	codec := &customCodec{}
+	
+	p := paginator.New(
+        &paginator.Config{
+            Rules: []paginator.Rule{
+                {
+                    Key: "ID",
+                },
+                {
+                    Key: "JoinedAt",
+                    Order: paginator.DESC,
+                    SQLRepr: "users.created_at",
+                    NULLReplacement: "1970-01-01",
+                },
+            },
+            Limit: 10,
+            // supply a custom implementation for the encoder/decoder 
+            CursorCodec: codec,
+            // Order here will apply to keys without order specified.
+            // In this example paginator will order by "ID" ASC, "JoinedAt" DESC.
+            Order: paginator.ASC, 
+        },
+    )
+    // ...
+    return p
 }
 ```
 

--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -5,3 +5,6 @@ type Cursor struct {
 	After  *string `json:"after" query:"after"`
 	Before *string `json:"before" query:"before"`
 }
+
+var beforePrefix = []byte("<")
+var afterPrefix = []byte(">")

--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -6,5 +6,5 @@ type Cursor struct {
 	Before *string `json:"before" query:"before"`
 }
 
-var beforePrefix = []byte("<")
-var afterPrefix = []byte(">")
+var BeforePrefix = []byte("<")
+var AfterPrefix = []byte(">")

--- a/cursor/decoder.go
+++ b/cursor/decoder.go
@@ -62,6 +62,28 @@ func (d *Decoder) Decode(cursor string, model interface{}) (fields []interface{}
 	return
 }
 
+// ParseDirectionAndCursor parses the direction and plain cursor string. The cursor string will then be fed to Decode()
+func (d *Decoder) ParseDirectionAndCursor(cursor string) (direction, plainCursor string, err error) {
+	b, err := base64.StdEncoding.DecodeString(cursor)
+	if err != nil {
+		return "", "", ErrInvalidCursor
+	}
+
+	var cursorBytes []byte
+
+	if bytes.HasPrefix(b, beforePrefix) {
+		direction = "before"
+		cursorBytes = bytes.TrimPrefix(b, beforePrefix)
+	} else if bytes.HasPrefix(b, afterPrefix) {
+		direction = "after"
+		cursorBytes = bytes.TrimPrefix(b, afterPrefix)
+	}
+
+	plainCursor = base64.StdEncoding.EncodeToString(cursorBytes)
+
+	return
+}
+
 // DecodeStruct decodes cursor into model, model must be a pointer to struct or it will panic.
 func (d *Decoder) DecodeStruct(cursor string, model interface{}) (err error) {
 	fields, err := d.Decode(cursor, model)

--- a/cursor/decoder.go
+++ b/cursor/decoder.go
@@ -71,12 +71,12 @@ func (d *Decoder) ParseDirectionAndCursor(cursor string) (direction, plainCursor
 
 	var cursorBytes []byte
 
-	if bytes.HasPrefix(b, beforePrefix) {
+	if bytes.HasPrefix(b, BeforePrefix) {
 		direction = "before"
-		cursorBytes = bytes.TrimPrefix(b, beforePrefix)
-	} else if bytes.HasPrefix(b, afterPrefix) {
+		cursorBytes = bytes.TrimPrefix(b, BeforePrefix)
+	} else if bytes.HasPrefix(b, AfterPrefix) {
 		direction = "after"
-		cursorBytes = bytes.TrimPrefix(b, afterPrefix)
+		cursorBytes = bytes.TrimPrefix(b, AfterPrefix)
 	}
 
 	plainCursor = base64.StdEncoding.EncodeToString(cursorBytes)

--- a/cursor/decoder_test.go
+++ b/cursor/decoder_test.go
@@ -65,3 +65,19 @@ func (s *decoderSuite) TestDecodeStructInvalidCursor() {
 	err := NewDecoder([]DecoderField{{Key: "Value"}}).DecodeStruct("123", struct{ Value string }{})
 	s.Equal(ErrInvalidCursor, err)
 }
+
+func (s *decoderSuite) TestParseDirectionAndCursor() {
+	e := NewEncoder([]EncoderField{{Key: "Slice"}})
+	c, err := e.Encode(struct{ Slice []string }{Slice: []string{"value"}})
+	s.Nil(err)
+
+	c, err = e.SerialiseDirectionAndCursor("after", c)
+	s.Nil(err)
+
+	dec := NewDecoder([]DecoderField{{Key: "Slice"}})
+	direction, plainCursor, err := dec.ParseDirectionAndCursor(c)
+
+	s.Nil(err)
+	s.Equal(direction, "after")
+	s.NotEmpty(plainCursor)
+}

--- a/cursor/encoder.go
+++ b/cursor/encoder.go
@@ -47,9 +47,9 @@ func (e *Encoder) SerialiseDirectionAndCursor(direction, plainCursor string) (st
 
 	switch strings.ToLower(direction) {
 	case "after":
-		directionPrefix = afterPrefix
+		directionPrefix = AfterPrefix
 	case "before":
-		directionPrefix = beforePrefix
+		directionPrefix = BeforePrefix
 	default:
 		return "", ErrInvalidDirection
 	}

--- a/cursor/encoder.go
+++ b/cursor/encoder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"reflect"
+	"strings"
 
 	"github.com/pilagod/gorm-cursor-paginator/v2/internal/util"
 )
@@ -32,6 +33,30 @@ func (e *Encoder) Encode(model interface{}) (string, error) {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(b), nil
+}
+
+// SerialiseDirectionAndCursor serialises the direction and plain cursor string.
+// This should be called with the result of Encode()
+func (e *Encoder) SerialiseDirectionAndCursor(direction, plainCursor string) (string, error) {
+	b, err := base64.StdEncoding.DecodeString(plainCursor)
+	if err != nil {
+		return "", ErrInvalidCursor
+	}
+
+	var directionPrefix []byte
+
+	switch strings.ToLower(direction) {
+	case "after":
+		directionPrefix = afterPrefix
+	case "before":
+		directionPrefix = beforePrefix
+	default:
+		return "", ErrInvalidDirection
+	}
+
+	cursorBytes := append(directionPrefix, b...)
+
+	return base64.StdEncoding.EncodeToString(cursorBytes), nil
 }
 
 func (e *Encoder) marshalJSON(model interface{}) ([]byte, error) {

--- a/cursor/encoder_test.go
+++ b/cursor/encoder_test.go
@@ -57,3 +57,12 @@ func (s *encoderSuite) TestSliceValue() {
 	_, err := e.Encode(struct{ Slice []string }{Slice: []string{"value"}})
 	s.Nil(err)
 }
+
+func (s *encoderSuite) TestSerialiseDirectionAndCursor() {
+	e := NewEncoder([]EncoderField{{Key: "Slice"}})
+	c, err := e.Encode(struct{ Slice []string }{Slice: []string{"value"}})
+	s.Nil(err)
+
+	_, err = e.SerialiseDirectionAndCursor("after", c)
+	s.Nil(err)
+}

--- a/cursor/error.go
+++ b/cursor/error.go
@@ -4,6 +4,7 @@ import "errors"
 
 // Errors for encoder
 var (
-	ErrInvalidCursor = errors.New("invalid cursor")
-	ErrInvalidModel  = errors.New("invalid model")
+	ErrInvalidCursor    = errors.New("invalid cursor")
+	ErrInvalidModel     = errors.New("invalid model")
+	ErrInvalidDirection = errors.New("invalid direction")
 )

--- a/paginator/cursor.go
+++ b/paginator/cursor.go
@@ -21,6 +21,18 @@ type CursorCodec interface {
 		cursor string,
 		model interface{},
 	) ([]interface{}, error)
+
+	// ParseDirectionAndCursor parses the direction and plain cursor. The resulting cursor can be fed to Decode()
+	ParseDirectionAndCursor(
+		cursor string,
+	) (direction, plainCursor string, err error)
+
+	// SerialiseDirectionAndCursor takes a direction and the plain cursor result from Encode()
+	// and serialises it into a directional cursor
+	SerialiseDirectionAndCursor(
+		direction string,
+		plainCursor string,
+	) (cursor string, err error)
 }
 
 // JSONCursorCodec encodes/decodes cursor in JSON format
@@ -41,4 +53,12 @@ func (*JSONCursorCodec) Decode(
 	model interface{},
 ) ([]interface{}, error) {
 	return pc.NewDecoder(fields).Decode(cursor, model)
+}
+
+func (*JSONCursorCodec) ParseDirectionAndCursor(cursor string) (direction, plainCursor string, err error) {
+	return pc.NewDecoder(nil).ParseDirectionAndCursor(cursor)
+}
+
+func (*JSONCursorCodec) SerialiseDirectionAndCursor(direction, plainCursor string) (string, error) {
+	return pc.NewEncoder(nil).SerialiseDirectionAndCursor(direction, plainCursor)
 }

--- a/paginator/cursor.go
+++ b/paginator/cursor.go
@@ -1,6 +1,44 @@
 package paginator
 
-import "github.com/pilagod/gorm-cursor-paginator/v2/cursor"
+import (
+	pc "github.com/pilagod/gorm-cursor-paginator/v2/cursor"
+)
 
 // Cursor re-exports cursor.Cursor
-type Cursor = cursor.Cursor
+type Cursor = pc.Cursor
+
+// CursorCodec encodes/decodes cursor
+type CursorCodec interface {
+	// Encode encodes model fields into cursor
+	Encode(
+		fields []pc.EncoderField,
+		model interface{},
+	) (string, error)
+
+	// Decode decodes cursor into model fields
+	Decode(
+		fields []pc.DecoderField,
+		cursor string,
+		model interface{},
+	) ([]interface{}, error)
+}
+
+// JSONCursorCodec encodes/decodes cursor in JSON format
+type JSONCursorCodec struct{}
+
+// Encode encodes model fields into JSON format cursor
+func (*JSONCursorCodec) Encode(
+	fields []pc.EncoderField,
+	model interface{},
+) (string, error) {
+	return pc.NewEncoder(fields).Encode(model)
+}
+
+// Decode decodes JSON format cursor into model fields
+func (*JSONCursorCodec) Decode(
+	fields []pc.DecoderField,
+	cursor string,
+	model interface{},
+) ([]interface{}, error) {
+	return pc.NewDecoder(fields).Decode(cursor, model)
+}

--- a/paginator/option.go
+++ b/paginator/option.go
@@ -1,5 +1,7 @@
 package paginator
 
+import "github.com/pilagod/gorm-cursor-paginator/v2/cursor"
+
 type Flag string
 
 const (
@@ -28,6 +30,8 @@ type Config struct {
 	After         string
 	Before        string
 	AllowTupleCmp Flag
+
+	CursorCodecFactory func(encoderFields []cursor.EncoderField, decoderFields []cursor.DecoderField) CursorCodec
 }
 
 // Apply applies config to paginator
@@ -53,6 +57,10 @@ func (c *Config) Apply(p *Paginator) {
 	}
 	if c.AllowTupleCmp != "" {
 		p.SetAllowTupleCmp(c.AllowTupleCmp == TRUE)
+	}
+
+	if c.CursorCodecFactory != nil {
+		p.SetCursorCodecFactory(c.CursorCodecFactory)
 	}
 }
 

--- a/paginator/option.go
+++ b/paginator/option.go
@@ -1,7 +1,5 @@
 package paginator
 
-import "github.com/pilagod/gorm-cursor-paginator/v2/cursor"
-
 type Flag string
 
 const (
@@ -14,6 +12,7 @@ var defaultConfig = Config{
 	Limit:         10,
 	Order:         DESC,
 	AllowTupleCmp: FALSE,
+	CursorCodec:   &JSONCursorCodec{},
 }
 
 // Option for paginator
@@ -30,8 +29,7 @@ type Config struct {
 	After         string
 	Before        string
 	AllowTupleCmp Flag
-
-	CursorCodecFactory func(encoderFields []cursor.EncoderField, decoderFields []cursor.DecoderField) CursorCodec
+	CursorCodec   CursorCodec
 }
 
 // Apply applies config to paginator
@@ -58,9 +56,8 @@ func (c *Config) Apply(p *Paginator) {
 	if c.AllowTupleCmp != "" {
 		p.SetAllowTupleCmp(c.AllowTupleCmp == TRUE)
 	}
-
-	if c.CursorCodecFactory != nil {
-		p.SetCursorCodecFactory(c.CursorCodecFactory)
+	if c.CursorCodec != nil {
+		p.SetCursorCodec(c.CursorCodec)
 	}
 }
 
@@ -110,5 +107,12 @@ func WithBefore(c string) Option {
 func WithAllowTupleCmp(flag Flag) Option {
 	return &Config{
 		AllowTupleCmp: flag,
+	}
+}
+
+// WithCursorCodec configures custom cursor codec
+func WithCursorCodec(codec CursorCodec) Option {
+	return &Config{
+		CursorCodec: codec,
 	}
 }

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -67,6 +67,21 @@ func (p *Paginator) SetBeforeCursor(beforeCursor string) {
 	p.cursor.Before = &beforeCursor
 }
 
+func (p *Paginator) SetCursor(cursor string) error {
+	direction, cursorString, err := p.cursorCodec.ParseDirectionAndCursor(cursor)
+	if err != nil {
+		return err
+	}
+
+	if direction == "after" {
+		p.SetAfterCursor(cursorString)
+	} else if direction == "before" {
+		p.SetBeforeCursor(cursorString)
+	}
+
+	return nil
+}
+
 // SetAllowTupleCmp enables or disables tuple comparison optimization
 func (p *Paginator) SetAllowTupleCmp(allow bool) {
 	p.allowTupleCmp = allow
@@ -312,6 +327,12 @@ func (p *Paginator) encodeCursor(elems reflect.Value, hasMore bool) (result Curs
 		if err != nil {
 			return Cursor{}, err
 		}
+
+		c, err = p.cursorCodec.SerialiseDirectionAndCursor("after", c)
+		if err != nil {
+			return Cursor{}, err
+		}
+
 		result.After = &c
 	}
 	// encode before cursor
@@ -320,6 +341,12 @@ func (p *Paginator) encodeCursor(elems reflect.Value, hasMore bool) (result Curs
 		if err != nil {
 			return Cursor{}, err
 		}
+
+		c, err = p.cursorCodec.SerialiseDirectionAndCursor("before", c)
+		if err != nil {
+			return Cursor{}, err
+		}
+
 		result.Before = &c
 	}
 	return

--- a/paginator/paginator_paginate_test.go
+++ b/paginator/paginator_paginate_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
@@ -858,6 +859,29 @@ func (c *idCursorCodec) Decode(fields []pc.DecoderField, cursor string, model in
 		return nil, err
 	}
 	return []interface{}{id}, nil
+}
+
+func (*idCursorCodec) ParseDirectionAndCursor(cursor string) (direction, plainCursor string, err error) {
+	if strings.HasPrefix(cursor, ">") {
+		direction = "after"
+		plainCursor = cursor[1:]
+	} else if strings.HasPrefix(cursor, "<") {
+		direction = "before"
+		plainCursor = cursor[1:]
+	} else {
+		err = ErrInvalidCursor
+	}
+	return
+}
+
+func (*idCursorCodec) SerialiseDirectionAndCursor(direction, plainCursor string) (string, error) {
+	if direction == "after" {
+		return fmt.Sprintf("%s%s", ">", plainCursor), nil
+	} else if direction == "before" {
+		return fmt.Sprintf("%s%s", "<", plainCursor), nil
+	} else {
+		return "", ErrInvalidCursor
+	}
 }
 
 func (s *paginatorSuite) TestPaginateCustomCodec() {


### PR DESCRIPTION
This PR adds support for directional cursors.

It was thrown together pretty quickly, so feedback/checking for bugs is appreciated. It should be backwards compatible for the most part - the `Cursor` interface has been updated to take two new functions: `ParseDirectionAndCursor` & `SerialiseDirectionAndCursor`. Under the hood these just append a marker for the direction - `Encode` and `Decode` still exist and do most of the heavy lifting.

I have opted not to remove the original `SetBeforeCursor`/`SetAfterCursor` logic, as I'm not sure if there was a reason behind that initial decision that means it's still a vaild usecase. If not then this PR can be simplified, contributions welcome.

There is scope for end users to mess things up if they inadvertently mix non-directional cursors with directional cursors, though I've updated the docs, and it should be relatively self-explanatory how it works, so I'm not sure how much of an issue that really is.

Thoughts and feedback welcome, @pilagod & @Virviil pinging as you've both raised/discussed related issues in #66 & #67 respectively.